### PR TITLE
fix: remove unsuppoted latex macro

### DIFF
--- a/checkermain.sh
+++ b/checkermain.sh
@@ -8,8 +8,8 @@ gif_token="${2}"
 
 [[ -e ./config.conf ]] && . ./config.conf
 
-format_noerr(){ printf '$\\fbox{\\colorbox{#DAFAE2}{\\color{#126329}\\textsf{\\normalsize  \\&#x2611; \\kern{0.2cm}\\small  %s  }}}$' "${*}" ;}
-format_err(){ printf '$\\fbox{\\colorbox{#FFEBEA}{\\color{#82061E}\\textsf{\\normalsize  \\&#x26A0; \\kern{0.2cm}\\small  %s  }}}$' "${*}" ;} 
+format_noerr(){ printf '$\\fbox{\\color{#126329}\\textsf{\\normalsize  \\&#x2611; \\kern{0.2cm}\\small  %s  }}$' "${*}" ;}
+format_err(){ printf '$\\fbox{\\color{#82061E}\\textsf{\\normalsize  \\&#x26A0; \\kern{0.2cm}\\small  %s  }}$' "${*}" ;} 
 format_table(){ printf '| \x60%s\x60 | %s |\n' "${1}" "${2}" ;}
 
 # Append Header


### PR DESCRIPTION
## Description

Fixes the Repo checker.

## Motivation and Context

bug appears because of deprecation of colorbox

## Related Issue

None

## Checklist

Please review and complete these items before submitting your pull request:

- [x] I have tested my changes thoroughly and they work as expected.
- [x] I have included appropriate tests for any new features or bug fixes.
- [x] My code is well-formatted and complies with the ShellCheck standards.
- [x] I have updated the documentation (if applicable).
- [x] I have read and agree to the [code of conduct](CODE_OF_CONDUCT.md) and [contribution guidelines](CONTRIBUTING.md).

## Screenshots (if applicable)

None

## Additional Notes (if applicable)

None